### PR TITLE
[FIX] 홈 DevTalk 소개 섹션 정렬 및 패딩 통일, Detail 플로팅 버튼 중앙 정렬

### DIFF
--- a/src/components/common/Cta.tsx
+++ b/src/components/common/Cta.tsx
@@ -6,7 +6,7 @@ type CtaProps = {
 
 const Cta = ({ bodyText, buttonText, onClick }: CtaProps) => {
   return (
-    <div className="w-[375px] flex flex-col justify-center items-center gap-16 px-20 pt-20 pb-[24px]">
+    <div className="w-full flex flex-col justify-center items-center gap-16 px-20 pt-20 pb-[24px]">
       {bodyText && <div className="body-2-semibold text-grey-100">{bodyText}</div>}
       <button
         onClick={onClick}

--- a/src/pages/user/home/Home.tsx
+++ b/src/pages/user/home/Home.tsx
@@ -203,13 +203,13 @@ const Home = () => {
             <div className="flex flex-col pt-2.5 px-[24px]">
               <p className="text-black heading-3-medium">DevTalk이란?</p>
             </div>
-            <div className="flex flex-col justify-between px-5 pt-2.5 pb-5">
+            <div className="flex flex-col justify-between px-[24px] pt-2.5 pb-5">
               <img
                 src={IntroDevtalk}
                 alt="DevTalk 소개 이미지"
-                className="w-[335px] h-[196px] rounded-8"
+                className="w-full h-[196px] rounded-8 object-cover"
               />
-              <div className="flex flex-col w-[335px] h-[100px] pt-[16px] body-1-medium text-grey-700">
+              <div className="flex flex-col w-full pt-[16px] body-1-medium text-grey-700">
                 <p>2023년부터 지금까지,</p>
                 <p>
                   <span className="text-grey-700 font-bold">

--- a/src/pages/user/seminar/Detail.tsx
+++ b/src/pages/user/seminar/Detail.tsx
@@ -127,7 +127,7 @@ const SeminarDetail = () => {
           </div>
         </div>
       </div>
-      <div className="fixed bottom-0">
+      <div className="fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-[430px]">
         {isCurrentSeminar && liveActivate ? (
           <Cta
             bodyText="지금 바로 입장해 주세요!"


### PR DESCRIPTION
## 🧾 관련 이슈
 #51


## 🔍 구현한 내용
홈 DevTalk 소개 섹션 정렬 및 패딩 통일, Detail 플로팅 버튼 중앙 정렬



## 📸 스크린샷(선택사항)





## 🙌 리뷰어에게
